### PR TITLE
Ignore Alliance Orientation

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -169,10 +169,8 @@ public final class Constants {
     public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms spark max velocity lag
     // Speed for Neo Vortex at 6700 RPM, 6.75:1 gears and 4" wheels
     public static final double MAX_SPEED = Units.feetToMeters(6700 / 6.75 / 60 * 4 * Math.PI / 12);
-    public static final double SPEED_SCALING = 0.5; // Scale joystick inputs to limit speed
-    public static final double SPEED_SCALING_3 =
-        Math.pow(SPEED_SCALING, 1 / 3.0); // Scale for inputs^3
 
     public static final Boolean ENABLE_VISION = true;
+    public static final Boolean USE_ALLIANCE = false;
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.ElevatorSubsystem;
@@ -68,7 +69,7 @@ public class RobotContainer {
           .withControllerRotationAxis(() -> driverController.getRightX() * -1)
           .deadband(OIConstants.DEADBAND)
           .scaleTranslation(0.8)
-          .allianceRelativeControl(true);
+          .allianceRelativeControl(DriveConstants.USE_ALLIANCE);
 
   // Applies deadbands and inverts controls because joysticks
   // are back-right positive while robot

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -183,7 +183,8 @@ public class SwerveSubsystem extends SubsystemBase {
 
             var alliance = DriverStation.getAlliance();
             if (alliance.isPresent()) {
-              return alliance.get() == DriverStation.Alliance.Red;
+              return ((alliance.get() == DriverStation.Alliance.Red)
+                  && DriveConstants.USE_ALLIANCE);
             }
             return false;
           },


### PR DESCRIPTION
Fixes #14
Added flag to ignore or use the alliance. It is set to false this year as the map is symmetrical.