### PR TITLE
Cleanup elevator model

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -101,10 +101,10 @@ public final class Constants {
     // Constants tunable through TunableNumbers
     public static final double ELEVATOR_KP = 15.0;
     public static final double ELEVATOR_KS = 0.1;
-    public static final double ELEVATOR_KG = 0.65;
-    public static final double ELEVATOR_KV_VOLTS_PER_METER_PER_SEC = 24.55;
-    public static final double ELEVATOR_MAX_VELOCITY_METERS_PER_SEC = 0.5;
-    public static final double ELEVATOR_MAX_ACCELERATION_METERS_PER_SEC2 = 2.0;
+    public static final double ELEVATOR_KG = 2.5;
+    public static final double ELEVATOR_KV_VOLTS_PER_METER_PER_SEC = 3.5;
+    public static final double ELEVATOR_MAX_VELOCITY_METERS_PER_SEC = 1.0;
+    public static final double ELEVATOR_MAX_ACCELERATION_METERS_PER_SEC2 = 4.0;
 
     // Spool Diameter in Inches
     public static final double SPOOL_DIAMETER = Units.inchesToMeters(1.73);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -272,6 +272,7 @@ public class RobotContainer {
    */
   public void disableSubsystems() {
     robotClaw.disable();
+    robotElevator.disable();
     robotIntake.disableIntake();
     DataLogManager.log("disableSubsystems");
   }

--- a/src/main/java/frc/sim/Constants.java
+++ b/src/main/java/frc/sim/Constants.java
@@ -2,7 +2,6 @@ package frc.sim;
 
 import edu.wpi.first.math.util.Units;
 import frc.robot.Constants.ClawConstants;
-import frc.robot.Constants.ElevatorConstants;
 
 /** Constants utility class for the claw simulation. */
 public final class Constants {
@@ -17,7 +16,6 @@ public final class Constants {
       throw new IllegalStateException("ClawSim Utility Class");
     }
 
-    public static final double CLAW_REDUCTION = ClawConstants.GEAR_RATIO;
     public static final double CLAW_MASS_KG = 6.0;
     public static final double CLAW_LENGTH_INCHES = 12;
     public static final double CLAW_LENGTH_METERS = Units.inchesToMeters(CLAW_LENGTH_INCHES);
@@ -34,9 +32,10 @@ public final class Constants {
       throw new IllegalStateException("ElevatorSimConstants Utility Class");
     }
 
-    public static final double ELEVATOR_REDUCTION = ElevatorConstants.GEAR_RATIO;
-    public static final double ELEVATOR_DRUM_RADIUS = Units.inchesToMeters(0.5);
-    public static final double CARRIAGE_MASS = 28.4; // kg
+    // The effective load lifted by the elevator. For a continuous elevator this is the total
+    // moving mass. For a two stage cascade this is the mass of the first moving stage plus
+    // two times the mass of the carriage.
+    public static final double EFFECTIVE_MASS = 20.0; // kg
   }
 
   /** Drivetrain simulation constants. */


### PR DESCRIPTION
Remove duplicate sim constants. Change elevator sim to specifically show effect of the cascade. Also disable elevator subsystem on robot disable, so tunable numbers can be changed.